### PR TITLE
Take home assessment

### DIFF
--- a/modules/custom/tableau_accessibility_block/README.md
+++ b/modules/custom/tableau_accessibility_block/README.md
@@ -1,0 +1,35 @@
+The goal is to build a Drupal 8 module. It should:
+  - Define a custom block that contains a HTML <button>.
+  - This block should be placed on every node.
+  - When a person clicks the button, make an AJAX request to an internal API
+    endpoint (defined below) to retrieve the accessibility analysis for the
+    page
+    - There are 3 nodes provided in the test database
+  - For the retrieved violations, please enumerate them by category and show
+    the count per category below the HTML <button>
+    - Style each category and count with CSS. Red = bad, green = good. A count
+      less-than-or-equal to 2 is considered good. Feel free to use whatever
+      hex / color name you'd like :)
+  - Build a controller that provides an internal API endpoint for the AJAX
+    request to consume. It should live at /api/accessibility
+    - The controller should forward a call to this Google cloud function, it
+      is available via HTTP at
+
+      https://us-central1-api-project-30183362591.cloudfunctions.net/axe-puppeteer-test
+
+    - It accepts a GET parameter of url={page_url}, so an example call would
+      look like:
+
+      https://us-central1-api-project-30183362591.cloudfunctions.net/axe-puppeteer-test?url=https://dev-tech-homework.pantheonsite.io/node/1
+
+    - We realize this is odd to do for a local dev url, so please use
+
+      https://dev-tech-homework.pantheonsite.io/node/1
+
+    - The call should be made with an authentication header: x-tableau-auth
+    - The value of the header should be:
+
+    AOaxT3DBGfyXtR68PgFzcZma4bfzLeuLFaLuX9jGHC
+
+    - Please make it so that the value of the header is configurable and can
+      be updated by an admin user in a config form

--- a/modules/custom/tableau_accessibility_block/config/install/block.block.tableauaccessibilityblock.yml
+++ b/modules/custom/tableau_accessibility_block/config/install/block.block.tableauaccessibilityblock.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - tableau_accessibility_block
+  theme:
+    - bartik
+id: tableauaccessibilityblock
+theme: bartik
+region: sidebar_first
+weight: 0
+provider: null
+plugin: tableau_accessibility_block
+settings:
+  id: tableau_accessibility_block
+  label: 'Tableau Accessibility Block'
+  provider: tableau_accessibility_block
+  label_display: '0'
+visibility: {  }

--- a/modules/custom/tableau_accessibility_block/config/install/tableau_accessibility_block.settings.yml
+++ b/modules/custom/tableau_accessibility_block/config/install/tableau_accessibility_block.settings.yml
@@ -1,0 +1,8 @@
+base_url:
+  value: 'https://dev-tech-homework.pantheonsite.io'
+external_endpoint:
+  value: 'https://us-central1-api-project-30183362591.cloudfunctions.net/axe-puppeteer-test'
+authentication_header:
+  value: 'x-tableau-auth'
+header_value:
+  value: 'AOaxT3DBGfyXtR68PgFzcZma4bfzLeuLFaLuX9jGHC'

--- a/modules/custom/tableau_accessibility_block/css/tab-block.css
+++ b/modules/custom/tableau_accessibility_block/css/tab-block.css
@@ -1,0 +1,10 @@
+.js-tab-error {
+  color: #ff0000;
+}
+.js-tab-success {
+  color: #00ff00;
+}
+.js-tab-data-list {
+  margin: 1.5em 0;
+  padding-left: 1.5em;
+}

--- a/modules/custom/tableau_accessibility_block/js/tab-block.js
+++ b/modules/custom/tableau_accessibility_block/js/tab-block.js
@@ -1,0 +1,61 @@
+(function ($, Drupal) {
+  Drupal.behaviors.tableau_accessibility_block_init = {
+    attach: function (context, settings) {
+        accessibilityCheck($('.tableau-accessibility-block-content'));
+    }
+  };
+
+  function accessibilityCheck($elem) {
+    $elem.once('button').each(function(i) {
+      let $button = $elem.find('button');
+      $button.on('click', function(e) {
+        e.preventDefault();
+        $button.attr('disabled','disabled');
+        let pathToCheck = window.location.pathname;
+        $.ajax({
+          url: '/api/accessibility?url=' + pathToCheck,
+          cache: false,
+        }).done(function(res) {
+          let $responseData = $('<ul />', {
+            'id' : 'js-tab-response-data-' + i,
+            'class' : 'js-tab-data-list',
+          });
+          $elem.append($responseData);
+          if(res.data && res.status == 200) {
+            // output the results, if we could get them.
+            // loop through the results and assign them classes depending on good/bad results per instructions
+            // assign <li> elements with 'js-tab-success' class to make them green.
+          } else {
+            // no data, or API error
+            let $dataError = $('<li />', {
+              'class' : 'js-tab-error',
+              'text' : 'Error getting data from the API',
+            });
+            $responseData.append($dataError);
+          }
+        });
+        // not going to use fetch until I can get the API working, to be able to test properly.
+        /*
+        fetch('/api/accessibility?url=' + window.location.href, {
+          method: "GET",
+          headers: headers,
+        }).then(res => {
+          if(!res.ok) {
+            $elem.attr('data-message','Network response was not ok.');
+          } else {
+            let $responseData = $('<ul />', {
+              'id' : 'js-tab-response-data-' + i,
+            });
+            $elem.append($responseData);
+            console.log(res);
+          }
+          //res.json();
+        }).catch((error) => {
+          console.error('Error: ', error);
+        });
+        */
+      });
+    });
+  }
+
+})(jQuery, Drupal);

--- a/modules/custom/tableau_accessibility_block/src/Controller/Endpoint.php
+++ b/modules/custom/tableau_accessibility_block/src/Controller/Endpoint.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Drupal\tableau_accessibility_block\Controller;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller routines for the custom endpoint.
+ */
+class Endpoint extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getModuleName() {
+    return 'tableau_accessibility_controller';
+  }
+
+  /**
+   * The configFactory object used to manage configurations.
+   *
+   * @var Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * The requestStack object used to collect the query string.
+   *
+   * @var Symfony\Component\HttpFoundation\RequestStack
+   */
+  private $requestStack;
+
+  /**
+   * The httpClient object used to send a request to the 3rd party API endpoint.
+   *
+   * @var GuzzleHttp\Client
+   */
+  private $httpClient;
+
+  /**
+   * The logger object used for sending log messages for debugging purposes.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelFactory
+   */
+  private $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactory $configFactory, RequestStack $requestStack, Client $httpClient, LoggerChannelFactory $logger) {
+    $this->configFactory = $configFactory;
+    $this->requestStack = $requestStack;
+    $this->http_client = $httpClient;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('request_stack'),
+      $container->get('http_client'),
+      $container->get('logger.factory')
+    );
+  }
+
+  /**
+   * Constructs a route for accessing the 3rd party API.
+   *
+   * The router _controller callback, maps the path
+   * 'api/accessibility' to this method.
+   *
+   * _controller callbacks return a JSON response for our JS can use
+   */
+  public function checkUrl() {
+
+    // Get the query parameter from the URL.
+    $url = $this->requestStack->getCurrentRequest()->query->get('url');
+
+    if (!$url) {
+      $this->logger->get('tableau_accessibility_block')->notice('Missing required "url" query parameter.', []);
+      return new JsonResponse([
+        'data' => 'Invalid query string',
+        'method' => 'GET',
+        'status' => 400,
+      ]);
+    }
+
+    // Load settings.
+    $config = $this->configFactory->get('tableau_accessibility_block.settings');
+    // Get values to use from the config.
+    $base_url = $config->get('base_url.value');
+    $external_endpoint = $config->get('external_endpoint.value');
+    $authentication_header = $config->get('authentication_header.value');
+    $header_value = $config->get('header_value.value');
+
+    /*
+     * Make the request using Guzzle
+     * note: having trouble getting a valid response from the API, given the
+     * authentication header and value provided, it looks like basic http
+     * authentication, however I get the same result regardless of
+     * username/password supplied.
+     */
+
+    $client = $this->http_client;
+    $options = [
+      'auth' => [$authentication_header, $header_value],
+      'headers' => [
+        'Accept' => 'application/json',
+      ],
+    ];
+    if(!empty($base_url)) {
+      $url = $base_url . $url;
+    } else {
+      $url = $_SERVER['SERVER_NAME'] . $url;
+    }
+    $requestUrl = $external_endpoint . '?url=' . $url;
+
+    try {
+      $request = $client->request('GET', $requestUrl, $options);
+      if ($request) {
+        /*
+         * If the request was good, I'm assuming the data would be returned as
+         * JSON - would return that to the JS file to display on the front end.
+         */
+        $result = json_decode($request->getBody(), TRUE);
+        // Logging so I know when the $request is good.
+        $this->logger->get('tableau_accessibility_block')->notice('API request result: @result', ['@result' => $result]);
+        return new JsonResponse([
+          'data' => $result,
+          'method' => 'GET',
+          'status' => 200,
+        ]);
+
+      }
+      else {
+        /*
+         * Depending on what a good API call looks like, we could have an
+         * alternative result here.
+         */
+        $this->logger->get('tableau_accessibility_block')->notice('API request failed.', []);
+        return new JsonResponse([
+          'data' => NULL,
+          'method' => 'GET',
+          'status' => 400,
+        ]);
+      }
+    }
+    catch (RequestException $requestException) {
+      /*
+       * Debug the $requestException - happening when I get a 403 status
+       * code response from the API.
+       */
+      $this->logger->get('tableau_accessibility_block')->notice('Request Exception', []);
+      return new JsonResponse([
+        'data' => NULL,
+        'method' => 'GET',
+        'status' => 400,
+      ]);
+    }
+
+  }
+
+}

--- a/modules/custom/tableau_accessibility_block/src/Form/EndpointSettings.php
+++ b/modules/custom/tableau_accessibility_block/src/Form/EndpointSettings.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\tableau_accessibility_block\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Implements the EndpointSettings form controller.
+ *
+ * This class uses creates a configuration form used to manage the values
+ * used to access the API.
+ *
+ * @see \Drupal\Core\Form\ConfigFormBase
+ */
+class EndpointSettings extends ConfigFormBase {
+
+  /**
+   * The configFactory object used to manage configurations.
+   *
+   * @var Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * Getter method for Form ID.
+   *
+   * The form ID is used in implementations of hook_form_alter() to allow other
+   * modules to alter the render array built by this form controller. It must be
+   * unique site wide. It normally starts with the providing module's name.
+   *
+   * @return string
+   *   The unique ID of the form defined by this class.
+   */
+  public function getFormId() {
+    return 'tableau_accessibility_block_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactory $configFactory) {
+    $this->configFactory = $configFactory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Build the simple form.
+   *
+   * A build form method constructs an array that defines how markup and
+   * other form elements are included in an HTML form.
+   *
+   * @param array $form
+   *   Default form array structure.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Object containing current form state.
+   *
+   * @return array
+   *   The render array defining the elements of the form.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Load settings.
+    $config = $this->configFactory->get('tableau_accessibility_block.settings');
+
+    $form['base_url'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Base URL'),
+      '#description' => $this->t('Used if needing to specify a different hostname, used for local development.'),
+      '#default_value' => $config->get('base_url.value'),
+    ];
+
+    $form['external_endpoint'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Endpoint URL'),
+      '#description' => $this->t('Provided URL that we send requests to.'),
+      '#default_value' => $config->get('external_endpoint.value'),
+    ];
+
+    $form['authentication_header'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Authentication Key'),
+      '#default_value' => $config->get('authentication_header.value'),
+    ];
+
+    $form['header_value'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Authentication Value'),
+      '#default_value' => $config->get('header_value.value'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Implements form validation.
+   *
+   * The validateForm method is the default method called to validate input on
+   * a form.
+   *
+   * @param array $form
+   *   The render array of the currently built form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Object describing the current state of the form.
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // In case we need to validate the fields.
+  }
+
+  /**
+   * Implements a form submit handler.
+   *
+   * The submitForm method is the default method called for any submit elements.
+   *
+   * @param array $form
+   *   The render array of the currently built form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Object describing the current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    $config = $this->configFactory->getEditable('tableau_accessibility_block.settings');
+    $config->set('external_endpoint.value', $form_state->getValue('external_endpoint'));
+    $config->set('authentication_header.value', $form_state->getValue('authentication_header'));
+    $config->set('header_value.value', $form_state->getValue('header_value'));
+    $config->save();
+
+    return parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'tableau_accessibility_block.settings',
+    ];
+  }
+
+}

--- a/modules/custom/tableau_accessibility_block/src/Plugin/Block/AccessibilityBlock.php
+++ b/modules/custom/tableau_accessibility_block/src/Plugin/Block/AccessibilityBlock.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\tableau_accessibility_block\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a block.
+ *
+ * @Block(
+ *   id = "tableau_accessibility_block",
+ *   admin_label = @Translation("Tableau Accessibility Block"),
+ *   category = @Translation("Tableau")
+ * )
+ */
+class AccessibilityBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#theme' => 'tableau_accessibility_block__content',
+      '#cache' => [
+        'max-age' => 0,
+      ],
+      '#contextual_links' => [
+        'tableau_accessibility_block' => [
+          'route_parameters' => [],
+        ],
+      ],
+      '#attached' => [
+        'library' => [
+          'tableau_accessibility_block/tab.block',
+        ],
+      ],
+      '#is_active' => TRUE,
+    ];
+  }
+
+}

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.info.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.info.yml
@@ -1,0 +1,7 @@
+name: Tableau Accessibility Block
+core: 8.x
+description: Provides a block to check the accessbility analysis of each page.
+type: module
+dependencies:
+  - drupal:block
+core_version_requirement: ^8

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.install
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Installation functions for tableau_accessibility_block.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function tableau_accessibility_block_install() {
+  user_role_change_permissions('administrator', [
+    'Administer Tableau Accessibility Block Settings' => TRUE,
+  ]);
+}

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.libraries.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.libraries.yml
@@ -1,0 +1,11 @@
+tab.block:
+  version: VERSION
+  css:
+    theme:
+      css/tab-block.css: { minified: false }
+  js:
+    js/tab-block.js: { minified: false }
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/jquery.once

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.links.contextual.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.links.contextual.yml
@@ -1,0 +1,5 @@
+tableau_accessibility_block:
+  title: 'Accessibility Block Settings'
+  route_name: 'tableau_accessibility_block.settings'
+  group: 'tableau_accessibility_block'
+  weight: 1

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.links.menu.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.links.menu.yml
@@ -1,0 +1,6 @@
+tableau_accessibility_block.settings:
+  title: 'Tableau Accessibility Block Settings'
+  parent: system.admin_config_system
+  description: 'Manage Tableau Accessibility Block settings.'
+  route_name: tableau_accessibility_block.settings
+  weight: 99

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.module
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Module file for tableau_accessibility_block.
+ */
+
+/**
+ * Implements hook_block_theme().
+ */
+function tableau_accessibility_block_theme($existing, $type, $theme, $path) {
+  return [
+    'tableau_accessibility_block__content' => [
+      // In case we need to pass data to the twig template.
+      'variables' => [
+        'button_text' => 'Analyze Accessibility',
+      ],
+    ],
+  ];
+}

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.permissions.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.permissions.yml
@@ -1,0 +1,4 @@
+administer tableau accessibility block settings:
+  title: 'Administer Tableau Accessibility Block Settings'
+  description: 'Configure API endpoing settings.'
+  restrict access: TRUE

--- a/modules/custom/tableau_accessibility_block/tableau_accessibility_block.routing.yml
+++ b/modules/custom/tableau_accessibility_block/tableau_accessibility_block.routing.yml
@@ -1,0 +1,13 @@
+tableau_accessibility_block.settings:
+  path: '/admin/config/tableau-accessibility-settings'
+  defaults:
+    _form: '\Drupal\tableau_accessibility_block\Form\EndpointSettings'
+    _title: 'Tableau Accessibility Block Settings'
+  requirements:
+    _permission: 'administer tableau accessibility block settings'
+tableau_accessibility_block.endpoint:
+  path: '/api/accessibility'
+  defaults:
+    _controller: '\Drupal\tableau_accessibility_block\Controller\Endpoint::checkUrl'
+  requirements:
+    _permission: 'access content'

--- a/modules/custom/tableau_accessibility_block/templates/tableau-accessibility-block--content.html.twig
+++ b/modules/custom/tableau_accessibility_block/templates/tableau-accessibility-block--content.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * - button_text: Text variable set in the tableau_accessibility_block.module
+ *   theme function
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div class="tableau-accessibility-block-content">
+  <button>{{ button_text }}</button>
+</div>


### PR DESCRIPTION
Hello and thanks for allowing me to take a stab at this assessment!

I wasn't sure what to expect and was pleased with the challenges given. There were a few aspects of the challenge that were new to me, and gave me an opportunity to try my best to come up with solutions.

First, I've never used Guzzle before, which is what I chose to go with for accessing the external API endpoint. Second, I've never used a Google Cloud function before - which provided me with the greatest challenge. Given the requirement to use an authentication header and a value associated with it, I assumed it was basic http authentication, but wasn't ever able to get the API to respond. So either I was either incorrect about how to authenticate for API access, or the API wasn't working for me as it returned an HTTP 403 status code. In addition to using the built in auth parameter with Guzzle, I also tried sending a custom header with basic authentication syntax in place, which returned me with a HTTP status code of 400. I did install and look into using Google's Cloud SDK in an attempt to try to get an OAuth token, however I didn't have access to the project, and wasn't able to figure out how to get one with the information provided.

I did my best to complete the rest of the requirements without being able to access the API, you can see that I put in place some basic error handling and made it fail gracefully. Also if you attempt to access the internal API endpoint without a query parameter, I log the attempt, and provide a message to the user that there is a missing query string.

To summarize what I included in the module:
- A configuration form available to admins to manage the settings, which I created fields for a base url, the external endpoint, the authorization header as well as the header value. This can be accessed via the admin/config/tableau-accessibility-settings page, or through contextual links on the block itself.
- Preconfigured settings for the admin form
- Preconfigured settings for the block instance to be initiated on module install to show up on all pages
- A twig template with supporting theme function in the .module file to allow passing additional variables to the template file.
- I setup permissions to allow user roles access to manage the settings, and using the .install file set initial permissions.

Thank you again for the opportunity to show you what I can bring to the company!